### PR TITLE
Remove deprecated output methods

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,9 @@
 import {
   appendOutput,
-  output,
   setOutput,
 } from './output'
 
 export default {
   appendOutput,
-  output,
   setOutput,
 };

--- a/output.test.ts
+++ b/output.test.ts
@@ -1,57 +1,7 @@
 import { jest } from "@jest/globals";
-import { output, setOutput, appendOutput } from './output'
+import { setOutput, appendOutput } from './output'
 
 const log = jest.spyOn(console, "log");
-
-test("output values without keys", () => {
-  output("world");
-  output(undefined);
-  output(null);
-  output(true);
-  output(false);
-  output(123);
-  output(123.456);
-  output(["hello", "world"]);
-  output({ catchphrase: "that's too much, man!" });
-
-  expectLogs([
-    `airplane_output "world"`,
-    `airplane_output null`,
-    `airplane_output null`,
-    `airplane_output true`,
-    `airplane_output false`,
-    `airplane_output 123`,
-    `airplane_output 123.456`,
-    `airplane_output ["hello","world"]`,
-    `airplane_output {"catchphrase":"that's too much, man!"}`,
-  ]);
-});
-
-test("output values with keys", () => {
-  output("hello", "world");
-  output("hello", undefined);
-  output("hello", null);
-  output("hello", true);
-  output("hello", false);
-  output("hello", 123);
-  output("hello", 123.456);
-  output("hello", ["hello", "world"]);
-  output("hello", { catchphrase: "that's too much, man!" });
-  output("hello world", { catchphrase: "that's too much, man!" });
-
-  expectLogs([
-    `airplane_output:"hello" "world"`,
-    `airplane_output:"hello" null`,
-    `airplane_output:"hello" null`,
-    `airplane_output:"hello" true`,
-    `airplane_output:"hello" false`,
-    `airplane_output:"hello" 123`,
-    `airplane_output:"hello" 123.456`,
-    `airplane_output:"hello" ["hello","world"]`,
-    `airplane_output:"hello" {"catchphrase":"that's too much, man!"}`,
-    `airplane_output:"hello world" {"catchphrase":"that's too much, man!"}`,
-  ]);
-});
 
 test("set/append values without paths", () => {
   setOutput("world");

--- a/output.ts
+++ b/output.ts
@@ -1,37 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 
 /**
- * This produces an Airplane output (`value`) that is grouped with
- * other outputs with the same `key`. If a `key` is not provided,
- * a default key is used.
- *
- * To learn more about Airplane outputs, see the docs: https://docs.airplane.dev/reference/outputs
- *
- * @deprecated please use setOutput and appendOutput instead
- *
- * @example
- *   output("Task completed successfully.")
- *
- * @example
- *   output("error", "This is an error message")
- *
- * @example
- *   output("rows", { "name": "Carolyn", "occupation": "agent" })
- */
-export function output(keyOrValue: string | any, value?: any) {
-  if (arguments.length === 1) {
-    const output = keyOrValue === undefined ? null : JSON.stringify(keyOrValue);
-    logChunks(`airplane_output ${output}`);
-  } else {
-    if (typeof keyOrValue !== "string") {
-      throw new Error("Expected keyOrValue to be type string");
-    }
-    const output = value === undefined ? null : JSON.stringify(value);
-    logChunks(`airplane_output:"${keyOrValue}" ${output}`);
-  }
-}
-
-/**
  * This sets the Airplane output (`value`). If a path is provided, it sets the
  * portion of the JSON output described by the path.
  *


### PR DESCRIPTION
These methods were deprecated. We now remove them and will release a `0.4.0` of this package without them.