### PR TITLE
Run tests on all node versions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   plugins: ["import", "@typescript-eslint", "prefer-arrow"],
   rules: {
-    "prettier/prettier": "error",
+    "prettier/prettier": ["error", { endOfLine: "auto" }],
     // Upgrade this from warning to error
     "@typescript-eslint/no-unused-vars": [
       "error",

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 18
           - 16
           - 14
-          - 12
         os:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ jobs:
       matrix:
         node-version:
           - 16
-          - 15
           - 14
           - 12
         os:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,25 @@ name: tests
 on: push
 jobs:
   run:
-    runs-on: ubuntu-latest
+    name: node:${{ matrix.node-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 16
+          - 15
+          - 14
+          - 12
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
       - run: yarn
       - run: yarn lint
       - run: yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # Example task for local testing
 example/
+
+# VSCode
+.vscode

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": "^14 || ^16 || ^18"
+  },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node"


### PR DESCRIPTION
Updates our test suite to run on all versions of Node.js that are currently supported on Airplane, [except Node 12 and 15](https://linear.app/airplane/issue/AIR-3536/deprecate-node-12-and-15). It also adds [Node 18](https://linear.app/airplane/issue/AIR-3549/support-node-18) given we'll be adding support for it to Airplane soon.

We don't include Node 12 support here since `node-fetch` uses the `node:` protocol (e.g. `node:http`) which is only available in ESM mode in Node 12. For folks using the Node 12 runtime, they can continue to use `v0.1.2`.

Based on: https://github.com/sindresorhus/got/blob/main/.github/workflows/main.yml