### PR TITLE
Fix missing `dist` folder in prerelease

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,6 @@ Then, deploy a new version with `np`:
 ```sh
 # Run build to create the dist/ directory.
 yarn build
-# The --preview will do a dry-run.
 # You may be prompted for 2FA authentication halfway ("waiting for input...").
-npx np patch --preview
+npx np
 ```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,8 +7,8 @@ To deploy a new version of this SDK, first merge your chages to `main`.
 Then, deploy a new version with `np`:
 
 ```sh
-# Run build to create the dist/ directory.
-yarn build
 # You may be prompted for 2FA authentication halfway ("waiting for input...").
 npx np
+# This previews the release. To release:
+npx np --publish
 ```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "lint": "eslint --ext js,ts,yml,yaml,json --max-warnings=0 .",
     "lint:fix": "eslint --ext js,ts,yml,yaml,json --max-warnings=0 --fix .",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "prepublishOnly": "yarn build"
   },
   "files": [
     "dist"
@@ -54,5 +55,9 @@
     "node-fetch": "3.2.3",
     "query-string": "7.1.1",
     "uuid": "8.3.2"
+  },
+  "np": {
+    "message": "Release v%s",
+    "preview": true
   }
 }


### PR DESCRIPTION
`v0.2.0-0` did not include the `dist/` folder. I tweaked the release process to automatically run `yarn build` to avoid this issue.

I'll release as `v0.2.0-1` once merged.