### PR TITLE
Support passing in authn to execute as params

### DIFF
--- a/fetch.test.ts
+++ b/fetch.test.ts
@@ -19,7 +19,7 @@ test("validates options", () => {
       host: "https://api.airplane.dev",
       token: "",
     });
-  }).toThrowError("expected an authentication token");
+  }).toThrowError("expected an authentication method");
 });
 
 describe("get", () => {

--- a/fetch.ts
+++ b/fetch.ts
@@ -7,14 +7,16 @@ import { version } from "./package.json";
 
 export type FetchOptions = {
   host: string;
-  token: string;
+  token?: string;
+  apiKey?: string;
   retryDelay?: (attempt: number) => number;
 };
 
 // Fetcher is a wrapper around node-fetch with reasonable defaults that understands the Airplane API format.
 export class Fetcher {
   private host: string;
-  private token: string;
+  private token?: string;
+  private apiKey?: string;
   private fetch: ReturnType<typeof withFetchRetries>;
   private retryDelay: FetchOptions["retryDelay"];
 
@@ -23,11 +25,12 @@ export class Fetcher {
       throw new Error("expected an api host");
     }
     this.host = opts.host;
-
-    if (!opts.token) {
-      throw new Error("expected an authentication token");
-    }
     this.token = opts.token;
+    this.apiKey = opts.apiKey;
+
+    if (!this.token && !this.apiKey) {
+      throw new Error("expected an authentication method");
+    }
 
     const defaultRetryDelay: FetchOptions["retryDelay"] = (attempt) => {
       return [0, 100, 200, 400, 600, 800, 1000][attempt] ?? 1000;
@@ -75,14 +78,20 @@ export class Fetcher {
     const url = new URL(this.host);
     url.pathname = path;
     url.search = params ? querystring.stringify(params) : "";
+    const headers: HeadersInit = {
+      "X-Airplane-Client-Kind": "sdk/node",
+      "X-Airplane-Client-Version": version,
+    };
+    if (this.token) {
+      headers["X-Airplane-Token"] = this.token;
+    }
+    if (this.apiKey) {
+      headers["X-Airplane-API-Key"] = this.apiKey;
+    }
 
     const response = await this.fetch(url.toString(), {
       method: "get",
-      headers: {
-        "X-Airplane-Token": this.token,
-        "X-Airplane-Client-Kind": "sdk/node",
-        "X-Airplane-Client-Version": version,
-      },
+      headers,
     });
 
     if (response.status >= 200 && response.status < 300) {
@@ -95,16 +104,22 @@ export class Fetcher {
   async post<Output = unknown>(path: string, body?: Record<string, unknown>): Promise<Output> {
     const url = new URL(this.host);
     url.pathname = path;
+    const headers: HeadersInit = {
+      "Content-Type": "application/json",
+      "X-Airplane-Client-Kind": "sdk/node",
+      "X-Airplane-Client-Version": version,
+    };
+    if (this.token) {
+      headers["X-Airplane-Token"] = this.token;
+    }
+    if (this.apiKey) {
+      headers["X-Airplane-API-Key"] = this.apiKey;
+    }
 
     const response = await this.fetch(url.toString(), {
       method: "post",
       body: body ? JSON.stringify(body) : undefined,
-      headers: {
-        "Content-Type": "application/json",
-        "X-Airplane-Token": this.token,
-        "X-Airplane-Client-Kind": "sdk/node",
-        "X-Airplane-Client-Version": version,
-      },
+      headers,
     });
 
     if (response.status >= 200 && response.status < 300) {

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import { appendOutput, setOutput } from "./output";
 import { execute } from "./tasks";
+export { TaskClient, ExecuteOptions, TaskClientOptions } from "./tasks";
 
 export default {
   appendOutput,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "hello@airplane.dev",
   "license": "MIT",
   "scripts": {
-    "test": "rm -rf dist && jest --testTimeout 500",
+    "test": "jest --testTimeout 500",
     "test:watch": "jest --watch",
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "lint": "eslint --ext js,ts,yml,yaml,json --max-warnings=0 .",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "scripts": {
     "test": "rm -rf dist && jest --testTimeout 500",
+    "test:watch": "jest --watch",
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "lint": "eslint --ext js,ts,yml,yaml,json --max-warnings=0 .",
     "lint:fix": "eslint --ext js,ts,yml,yaml,json --max-warnings=0 --fix .",

--- a/tasks.test.ts
+++ b/tasks.test.ts
@@ -3,49 +3,70 @@ import nock from "nock";
 import { execute, RunStatus } from "./tasks";
 
 const OLD_ENV = process.env;
-afterAll(() => {
-  process.env = OLD_ENV;
-});
 
-test("execute", async () => {
+describe("execute", () => {
   const host = "http://localhost:51234";
-  nock.disableNetConnect();
 
-  expect.assertions(1);
+  beforeEach(() => {
+    process.env = OLD_ENV;
 
-  process.env.AIRPLANE_API_HOST = host;
-  process.env.AIRPLANE_TOKEN = "token123";
+    nock.disableNetConnect();
+    expect.assertions(1);
+    nock(host)
+      .post("/v0/tasks/execute", {
+        slug: "hello_world",
+        paramValues: {
+          name: "colin",
+        },
+      })
+      .reply(200, {
+        runID: "run123",
+      })
+      .get("/v0/runs/get?id=run123")
+      .reply(200, {
+        id: "run123",
+        status: RunStatus.Succeeded,
+        paramValues: { name: "colin" },
+        taskID: "task123",
+      })
+      .get("/v0/runs/getOutputs?id=run123")
+      .reply(200, {
+        output: "hello, colin!",
+      });
+  });
+  test("with token from env var", async () => {
+    process.env.AIRPLANE_API_HOST = host;
+    process.env.AIRPLANE_TOKEN = "token123";
 
-  nock(host)
-    .post("/v0/tasks/execute", {
-      slug: "hello_world",
-      paramValues: {
-        name: "colin",
-      },
-    })
-    .reply(200, {
-      runID: "run123",
-    })
-    .get("/v0/runs/get?id=run123")
-    .reply(200, {
+    const run = await execute<string>("hello_world", {
+      name: "colin",
+    });
+    expect(run).toStrictEqual({
       id: "run123",
-      status: RunStatus.Succeeded,
-      paramValues: { name: "colin" },
       taskID: "task123",
-    })
-    .get("/v0/runs/getOutputs?id=run123")
-    .reply(200, {
+      paramValues: { name: "colin" },
+      status: RunStatus.Succeeded,
       output: "hello, colin!",
     });
-
-  const run = await execute<string>("hello_world", {
-    name: "colin",
   });
-  expect(run).toStrictEqual({
-    id: "run123",
-    taskID: "task123",
-    paramValues: { name: "colin" },
-    status: RunStatus.Succeeded,
-    output: "hello, colin!",
+
+  test("with passed in token and host", async () => {
+    const run = await execute<string>(
+      "hello_world",
+      {
+        name: "colin",
+      },
+      {
+        host,
+        token: "token123",
+      }
+    );
+    expect(run).toStrictEqual({
+      id: "run123",
+      taskID: "task123",
+      paramValues: { name: "colin" },
+      status: RunStatus.Succeeded,
+      output: "hello, colin!",
+    });
   });
 });

--- a/tasks.ts
+++ b/tasks.ts
@@ -72,3 +72,19 @@ export const execute = async <Output = unknown>(
     };
   });
 };
+
+export type TaskClientOptions = {
+  host?: string;
+  token?: string;
+  apiKey?: string;
+};
+export class TaskClient {
+  constructor(private readonly opts?: TaskClientOptions) {}
+
+  async execute<Output = unknown>(
+    slug: string,
+    params?: Record<string, unknown> | undefined | null
+  ): Promise<Run<typeof params, Output>> {
+    return execute(slug, params, this.opts);
+  }
+}

--- a/tasks.ts
+++ b/tasks.ts
@@ -20,13 +20,24 @@ export type Run<Input = unknown, Output = unknown> = {
   output: Output;
 };
 
+export type ExecuteOptions = {
+  host?: string;
+  token?: string;
+  apiKey?: string;
+};
+
 export const execute = async <Output = unknown>(
   slug: string,
-  params?: Record<string, unknown> | undefined | null
+  params?: Record<string, unknown> | undefined | null,
+  opts?: ExecuteOptions
 ): Promise<Run<typeof params, Output>> => {
+  const host = process?.env?.AIRPLANE_API_HOST || opts?.host || "";
+  const token = process?.env?.AIRPLANE_TOKEN || opts?.token;
+  const apiKey = process?.env?.AIRPLANE_API_KEY || opts?.apiKey;
   const fetcher = new Fetcher({
-    host: process.env.AIRPLANE_API_HOST ?? "",
-    token: process.env.AIRPLANE_TOKEN ?? "",
+    host,
+    token,
+    apiKey,
   });
 
   const { runID } = await fetcher.post<{


### PR DESCRIPTION
Support using `execute` in non-node environments without depending on environment variables. I'm [currently working around this](https://github.com/airplanedev/views/blob/1c80a979629a5cd432cef2ef76a50d34bbab0433/examples/executeTask/src/main.tsx#L10) in views, but it's icky.

Other than being able to pass authn/host directly to `execute`, I created a client that we can pass authn information to once and then continue to call execute - this seems like a more standard pattern, but definitely not necessary.

We also want to support apiKey authn because the CLI supports it.

FIXES AIR-3913