### PR TITLE
Support passing in env slug to execute

### DIFF
--- a/fetch.test.ts
+++ b/fetch.test.ts
@@ -20,13 +20,6 @@ test("validates options", () => {
       token: "",
     });
   }).toThrowError("expected an authentication method");
-
-  expect(() => {
-    new Fetcher({
-      host: "https://api.airplane.dev",
-      token: "foobar",
-    });
-  }).toThrowError("expected an env ID");
 });
 
 describe("get", () => {

--- a/fetch.ts
+++ b/fetch.ts
@@ -10,6 +10,7 @@ export type FetchOptions = {
   token?: string;
   apiKey?: string;
   envID?: string;
+  envSlug?: string;
   retryDelay?: (attempt: number) => number;
 };
 
@@ -18,7 +19,8 @@ export class Fetcher {
   private host: string;
   private token?: string;
   private apiKey?: string;
-  private envID: string;
+  private envID?: string;
+  private envSlug?: string;
   private fetch: ReturnType<typeof withFetchRetries>;
   private retryDelay: FetchOptions["retryDelay"];
 
@@ -37,10 +39,8 @@ export class Fetcher {
       throw new Error("expected a single authentication method");
     }
 
-    if (!opts.envID) {
-      throw new Error("expected an env ID");
-    }
     this.envID = opts.envID;
+    this.envSlug = opts.envSlug;
 
     const defaultRetryDelay: FetchOptions["retryDelay"] = (attempt) => {
       return [0, 100, 200, 400, 600, 800, 1000][attempt] ?? 1000;
@@ -90,7 +90,6 @@ export class Fetcher {
     url.search = params ? querystring.stringify(params) : "";
     const headers: HeadersInit = {
       "X-Airplane-Client-Kind": "sdk/node",
-      "X-Airplane-Env-ID": this.envID,
       "X-Airplane-Client-Version": version,
     };
     if (this.token) {
@@ -98,6 +97,12 @@ export class Fetcher {
     }
     if (this.apiKey) {
       headers["X-Airplane-API-Key"] = this.apiKey;
+    }
+    if (this.envID) {
+      headers["X-Airplane-Env-ID"] = this.envID;
+    }
+    if (this.envSlug) {
+      headers["X-Airplane-Env-Slug"] = this.envSlug;
     }
 
     const response = await this.fetch(url.toString(), {
@@ -117,7 +122,6 @@ export class Fetcher {
     url.pathname = path;
     const headers: HeadersInit = {
       "Content-Type": "application/json",
-      "X-Airplane-Env-ID": this.envID,
       "X-Airplane-Client-Kind": "sdk/node",
       "X-Airplane-Client-Version": version,
     };
@@ -126,6 +130,12 @@ export class Fetcher {
     }
     if (this.apiKey) {
       headers["X-Airplane-API-Key"] = this.apiKey;
+    }
+    if (this.envID) {
+      headers["X-Airplane-Env-ID"] = this.envID;
+    }
+    if (this.envSlug) {
+      headers["X-Airplane-Env-Slug"] = this.envSlug;
     }
 
     const response = await this.fetch(url.toString(), {

--- a/tasks.ts
+++ b/tasks.ts
@@ -25,6 +25,7 @@ export type ExecuteOptions = {
   token?: string;
   apiKey?: string;
   envID?: string;
+  envSlug?: string;
 };
 
 export const execute = async <Output = unknown>(
@@ -37,11 +38,13 @@ export const execute = async <Output = unknown>(
   const token = opts?.token || env?.AIRPLANE_TOKEN;
   const apiKey = opts?.apiKey || env?.AIRPLANE_API_KEY;
   const envID = opts?.envID || env?.AIRPLANE_ENV_ID;
+  const envSlug = opts?.envSlug || env?.AIRPLANE_ENV_SLUG;
   const fetcher = new Fetcher({
     host,
     token,
     apiKey,
     envID,
+    envSlug,
   });
 
   const { runID } = await fetcher.post<{


### PR DESCRIPTION
In addition to an env id, we want to support passing through an env slug. Views will use this for local dev - the user may specify an environment in which to test their view by specifying an env slug.

Additionally, passing no env id/slug is valid. This uses the default env.