### PR TITLE
Add builtins.sql.query function

### DIFF
--- a/builtins/sql.ts
+++ b/builtins/sql.ts
@@ -1,0 +1,17 @@
+import { Run, execute } from "tasks";
+
+export enum TransactionMode {
+  Auto = "auto",
+  ReadOnly = "readOnly",
+  ReadWrite = "readWrite",
+  None = "none",
+}
+
+export const query = async <Output = unknown>(
+  query: string,
+  db: string,
+  queryArgs?: Record<string, unknown> | undefined | null,
+  transactionMode: TransactionMode = TransactionMode.Auto
+): Promise<Run<Record<string, unknown> | undefined | null, Output>> => {
+  return execute("airplane:sql_query", { query, queryArgs, transactionMode }, { db });
+};

--- a/tasks.ts
+++ b/tasks.ts
@@ -30,6 +30,7 @@ export type ExecuteOptions = {
 export const execute = async <Output = unknown>(
   slug: string,
   params?: Record<string, unknown> | undefined | null,
+  resources?: Record<string, string> | undefined | null,
   opts?: ExecuteOptions
 ): Promise<Run<typeof params, Output>> => {
   const env = typeof process === "undefined" ? {} : process?.env;
@@ -49,6 +50,7 @@ export const execute = async <Output = unknown>(
   }>("/v0/tasks/execute", {
     slug,
     paramValues: params ?? {},
+    resources: resources ?? {},
   });
 
   // Poll until the run terminates:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "declaration": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "baseUrl": "."
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Adds a function that calls the execute api after structuring inputs correctly.

OQ:
What do we want resource structs to look like?
What should import of this function look like?