### PR TITLE
Determine internal execute method using AsyncLocalStorage

### DIFF
--- a/async.ts
+++ b/async.ts
@@ -1,0 +1,6 @@
+import { AsyncLocalStorage } from "@temporalio/workflow";
+export type AirplaneStore = {
+  runtime?: string;
+};
+
+export const _storage = new AsyncLocalStorage<AirplaneStore>();

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,8 @@ import { execute } from "./tasks";
 export { ExecuteOptions } from "./tasks";
 export * as resources from "./resources";
 
+export { _storage, AirplaneStore } from "./async";
+
 export default {
   appendOutput,
   setOutput,

--- a/tasks.ts
+++ b/tasks.ts
@@ -38,7 +38,6 @@ export type ExecuteOptions = {
   envID?: string;
   envSlug?: string;
   source?: string;
-  runtime?: string;
 };
 
 export const execute = async <Output = unknown>(

--- a/tasks.ts
+++ b/tasks.ts
@@ -59,7 +59,7 @@ export const executeInternal = async <Output = unknown>(
   if (Object.prototype.hasOwnProperty.call(_storage, "enabled")) {
     const store = _storage.getStore();
     if (store != null && store.runtime === "workflow") {
-      return durableExecute(slug, params, resources, opts);
+      return durableExecute(slug, params, opts);
     }
   }
 
@@ -103,10 +103,9 @@ export const executeInternal = async <Output = unknown>(
 export const durableExecute = async <Output = unknown>(
   slug: string,
   params: Record<string, unknown> | undefined | null,
-  resources?: Record<string, string> | undefined | null,
   opts?: ExecuteOptions
 ): Promise<Run<typeof params, Output>> => {
-  const runID = await executeTaskActivity(slug, params, resources, opts);
+  const runID = await executeTaskActivity(slug, params, opts);
 
   // Register termination signal for the workflow. We ensure signal name uniqueness by including the run ID of the task
   // being executed in the signal name, as a workflow task may execute any number of other tasks.


### PR DESCRIPTION
Previously, we would have to include the runtime as part of the `ExecuteOptions` passed to `airplane.execute` in order to let the SDK know whether to call the internal execute method for standard tasks, or workflow tasks, i.e. define something like:
```
export default async function(params) {
  return await airplane.execute("rest_task", undefined, {
    runtime: "workflow",
  });
}
```
This is somewhat redundant since the code above is already being executed as a workflow task, and the user shouldn't have to specify again that it needs to run in a durable context.

We utilize the `AsyncLocalStorage` class provided by Temporal (which is basically just a context-aware wrapper around the one from Node's `async_hooks`), to pass in metadata (like the runtime) such that is globally accessible during Workflow execution. This way, we can set the runtime in async local storage in the workflow shim and fetch it during execution, so that we only need to define:
```
export default async function(params) {
  return await airplane.execute("rest_task");
}
```

Tested locally on both standard and workflow tasks.