### PR TITLE
Use AIRPLANE_RUNTIME env var to determine internal execute method

### DIFF
--- a/tasks.ts
+++ b/tasks.ts
@@ -54,7 +54,9 @@ export const executeInternal = async <Output = unknown>(
   resources?: Record<string, string> | undefined | null,
   opts?: ExecuteOptions
 ): Promise<Run<typeof params, Output>> => {
-  if (opts?.runtime === "workflow") {
+  const env = typeof process === "undefined" ? {} : process?.env;
+  const envSlug = opts?.runtime || env?.AIRPLANE_RUNTIME;
+  if (envSlug === "workflow") {
     return durableExecute(slug, params, opts);
   }
 

--- a/tasks.ts
+++ b/tasks.ts
@@ -55,8 +55,8 @@ export const executeInternal = async <Output = unknown>(
   opts?: ExecuteOptions
 ): Promise<Run<typeof params, Output>> => {
   const env = typeof process === "undefined" ? {} : process?.env;
-  const envSlug = opts?.runtime || env?.AIRPLANE_RUNTIME;
-  if (envSlug === "workflow") {
+  const runtime = opts?.runtime || env?.AIRPLANE_RUNTIME || "standard";
+  if (runtime === "workflow") {
     return durableExecute(slug, params, opts);
   }
 


### PR DESCRIPTION
Now that we monkey patch `process.env` to make it accessible in the SDK, we can use the `AIRPLANE_RUNTIME` env var to determine whether or not to durably execute a task or execute it the standard way.

Related: https://github.com/airplanedev/lib/pull/159

Tested locally by deploying/running a workflow task without the runtime specified in ExecuteOptions.