### PR TITLE
Silence `np` warning from missing `files` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "engines": {
     "node": "^14 || ^16 || ^18"
   },
+  "files": [
+    "**/*"
+  ],
   "devDependencies": {
     "@babel/core": "7.17.9",
     "@babel/plugin-transform-modules-commonjs": "7.17.9",


### PR DESCRIPTION
This is a no-op change, but prevents `np` from printing this warning message:

```
(✖1) node-sdk ▶ npx np 0.2.0-10 --tag=next


Warning: No files field specified in package.json nor is a .npmignore file present. Having one of those will prevent you from accidentally publishing development-specific files along with your package's source code to npm.


Publish a new version of airplane (current: 0.2.0-8)
```

We are already selectively choosing which files to publish by publishing only the `dist` folder.