### PR TITLE
Remove error if no authn is provided

### DIFF
--- a/internal/api/fetcher.test.ts
+++ b/internal/api/fetcher.test.ts
@@ -19,7 +19,7 @@ test("validates options", () => {
       host: "https://api.airplane.dev",
       token: "",
     });
-  }).toThrowError("expected an authentication method");
+  }).not.toThrow();
 });
 
 describe("get", () => {

--- a/internal/api/fetcher.ts
+++ b/internal/api/fetcher.ts
@@ -34,9 +34,6 @@ export class Fetcher {
     this.token = opts.token;
     this.apiKey = opts.apiKey;
 
-    if (!this.token && !this.apiKey) {
-      throw new Error("expected an authentication method");
-    }
     if (this.token && this.apiKey) {
       throw new Error("expected a single authentication method");
     }


### PR DESCRIPTION
In production, views rely on session cookies to authn with the API - they do not explicitly pass in an authn token or api key. This error precludes this from working.