### PR TITLE
Add basic prompts: `airplane.input.text` 

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,7 @@ import * as rest from "./internal/builtins/rest";
 import * as slack from "./internal/builtins/slack";
 import * as sql from "./internal/builtins/sql";
 import { execute } from "./internal/execute";
+import * as input from "./internal/input";
 import { appendOutput, setOutput } from "./internal/output";
 
 // Export the core methods so they can be directly imported:
@@ -25,6 +26,7 @@ export default {
   rest,
   slack,
   sql,
+  input,
 };
 
 // Exported types

--- a/input.ts
+++ b/input.ts
@@ -1,0 +1,7 @@
+// Supports:
+// import { text } from 'airplane/input'
+export * from "./internal/input";
+
+// Supports:
+// import input from 'airplane/input'
+export * as default from "./internal/input";

--- a/internal/api/client.ts
+++ b/internal/api/client.ts
@@ -1,5 +1,5 @@
 import { Fetcher } from "./fetcher";
-import { RunStatus } from "./types";
+import { ParamSchema, Prompt, RunStatus } from "./types";
 
 export type ClientOptions = {
   host?: string;
@@ -47,20 +47,34 @@ export class Client {
     return runID;
   }
 
-  async getRunOutput<Output = unknown>(runID: string): Promise<Output> {
-    const { output } = await this.fetcher.get<{ output: Output }>("/v0/runs/getOutputs", {
+  async getRunOutput<O = unknown>(runID: string): Promise<O> {
+    const { output } = await this.fetcher.get<{ output: O }>("/v0/runs/getOutputs", {
       id: runID,
     });
 
     return output;
   }
 
-  async getRun<ParamValues = unknown>(runID: string) {
+  async getRun<P = unknown>(runID: string) {
     return this.fetcher.get<{
       id: string;
       status: RunStatus;
-      paramValues: ParamValues;
+      paramValues: P;
       taskID: string;
     }>("/v0/runs/get", { id: runID });
+  }
+
+  async createPrompt(params: ParamSchema[]): Promise<string> {
+    const resp = await this.fetcher.post<{
+      id: string;
+    }>("/v0/prompts/create", { schema: { parameters: params } });
+    return resp.id;
+  }
+
+  async getPrompt(id: string): Promise<Prompt> {
+    const resp = await this.fetcher.get<{
+      prompt: Prompt;
+    }>("/v0/prompts/get", { id });
+    return resp.prompt;
   }
 }

--- a/internal/api/types.ts
+++ b/internal/api/types.ts
@@ -7,12 +7,12 @@ export enum RunStatus {
   Cancelled = "Cancelled",
 }
 
-export type Run<Input = unknown, Output = unknown> = {
+export type Run<P extends ParamValues = ParamValues, O = unknown> = {
   id: string;
   taskID: string;
-  paramValues: Input;
+  paramValues: P;
   status: RunStatus;
-  output: Output;
+  output: O;
 };
 
 export const isStatusTerminal = (status: RunStatus): boolean => {
@@ -24,4 +24,51 @@ export const isStatusTerminal = (status: RunStatus): boolean => {
     default:
       return false;
   }
+};
+
+export type ParamSchema<T extends ParamType = ParamType> = {
+  slug: string;
+  name: string;
+  desc?: string;
+  type: T;
+  component?: string;
+  default?: ParamJSTypes[T];
+  constraints: ParamConstraints<T>;
+};
+
+export type ParamConstraints<T extends ParamType = ParamType> = {
+  optional?: boolean;
+  regex?: string;
+  options?: Array<ParamJSTypes[T] | { label: string; value: ParamJSTypes[T] }>;
+};
+
+type ParamJSTypes = {
+  string: string;
+  boolean: boolean;
+  upload: string;
+  integer: number;
+  float: number;
+  date: string;
+  datetime: string;
+  configvar: string;
+};
+
+export type ParamType = keyof ParamJSTypes;
+
+export type ParamValue =
+  | undefined
+  | null
+  | Record<string, unknown> /* internal map|object type */
+  | unknown[] /* internal list type */
+  | (ParamJSTypes extends { [type: string]: infer I } ? I : never);
+
+export type ParamValues = {
+  [slug: string]: ParamValue;
+};
+
+export type Prompt = {
+  id: string;
+  schema: ParamSchema[];
+  values: ParamValues;
+  submittedAt: string | null;
 };

--- a/internal/builtins/email.ts
+++ b/internal/builtins/email.ts
@@ -1,5 +1,5 @@
 import { ClientOptions } from "../api/client";
-import { Run } from "../api/types";
+import { ParamValues, Run } from "../api/types";
 import { getRuntime } from "../runtime";
 
 export type Contact = {
@@ -16,7 +16,7 @@ export const message = async (
   subject = "",
   message = "",
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, MessageOutput>> => {
+): Promise<Run<ParamValues, MessageOutput>> => {
   return getRuntime().execute(
     "airplane:email_message",
     { sender, recipients, subject, message },

--- a/internal/builtins/mongodb.ts
+++ b/internal/builtins/mongodb.ts
@@ -1,5 +1,5 @@
 import { ClientOptions } from "../api/client";
-import { Run } from "../api/types";
+import { ParamValues, Run } from "../api/types";
 import { getRuntime } from "../runtime";
 
 export type DocumentOutput = Record<string, unknown>;
@@ -13,9 +13,7 @@ export const find = async (
   skip: number | undefined | null = null,
   limit: number | undefined | null = null,
   opts?: ClientOptions
-): Promise<
-  Run<Record<string, unknown> | undefined | null, DocumentOutput[] | undefined | null>
-> => {
+): Promise<Run<ParamValues, DocumentOutput[] | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_find",
     { collection, filter, projection, sort, skip, limit },
@@ -31,7 +29,7 @@ export const findOne = async (
   projection: Record<string, unknown> | undefined | null = null,
   sort: Record<string, unknown> | undefined | null = null,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, DocumentOutput | undefined | null>> => {
+): Promise<Run<ParamValues, DocumentOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_findOne",
     { collection, filter, projection, sort },
@@ -47,7 +45,7 @@ export const findOneAndDelete = async (
   projection: Record<string, unknown> | undefined | null = null,
   sort: Record<string, unknown> | undefined | null = null,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, DocumentOutput | undefined | null>> => {
+): Promise<Run<ParamValues, DocumentOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_findOneAndDelete",
     { collection, filter, projection, sort },
@@ -64,7 +62,7 @@ export const findOneAndUpdate = async (
   projection: Record<string, unknown> | undefined | null = null,
   sort: Record<string, unknown> | undefined | null = null,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, DocumentOutput | undefined | null>> => {
+): Promise<Run<ParamValues, DocumentOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_findOneAndUpdate",
     { collection, update, filter, projection, sort },
@@ -82,7 +80,7 @@ export const findOneAndReplace = async (
   sort: Record<string, unknown> | undefined | null = null,
   upsert: boolean | undefined | null = null,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, DocumentOutput | undefined | null>> => {
+): Promise<Run<ParamValues, DocumentOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_findOneAndReplace",
     { collection, replacement, filter, projection, sort, upsert },
@@ -100,7 +98,7 @@ export const insertOne = async (
   collection: string,
   document: Record<string, unknown>,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, InsertOneOutput | undefined | null>> => {
+): Promise<Run<ParamValues, InsertOneOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_insertOne",
     { collection, document },
@@ -118,9 +116,7 @@ export const insertMany = async (
   collection: string,
   documents: Record<string, unknown>[],
   opts?: ClientOptions
-): Promise<
-  Run<Record<string, unknown> | undefined | null, InsertManyOutput | undefined | null>
-> => {
+): Promise<Run<ParamValues, InsertManyOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_insertMany",
     { collection, documents },
@@ -143,7 +139,7 @@ export const updateOne = async (
   filter: Record<string, unknown> | undefined | null = null,
   upsert: boolean | undefined | null = null,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, UpdateOutput | undefined | null>> => {
+): Promise<Run<ParamValues, UpdateOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_updateOne",
     { collection, update, filter, upsert },
@@ -159,7 +155,7 @@ export const updateMany = async (
   filter: Record<string, unknown> | undefined | null = null,
   upsert: boolean | undefined | null = null,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, UpdateOutput | undefined | null>> => {
+): Promise<Run<ParamValues, UpdateOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_updateMany",
     { collection, update, filter, upsert },
@@ -177,7 +173,7 @@ export const deleteOne = async (
   collection: string,
   filter: Record<string, unknown>,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, DeleteOutput | undefined | null>> => {
+): Promise<Run<ParamValues, DeleteOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_deleteOne",
     { collection, filter },
@@ -191,7 +187,7 @@ export const deleteMany = async (
   collection: string,
   filter: Record<string, unknown>,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, DeleteOutput | undefined | null>> => {
+): Promise<Run<ParamValues, DeleteOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_deleteMany",
     { collection, filter },
@@ -205,9 +201,7 @@ export const aggregate = async (
   collection: string,
   pipeline: Record<string, unknown>[],
   opts?: ClientOptions
-): Promise<
-  Run<Record<string, unknown> | undefined | null, DocumentOutput[] | undefined | null>
-> => {
+): Promise<Run<ParamValues, DocumentOutput[] | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_aggregate",
     { collection, pipeline },
@@ -223,7 +217,7 @@ export const countDocuments = async (
   collection: string,
   filter: Record<string, unknown>,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, CountOutput | undefined | null>> => {
+): Promise<Run<ParamValues, CountOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_countDocuments",
     { collection, filter },
@@ -240,7 +234,7 @@ export const distinct = async (
   field: string,
   filter: Record<string, unknown>,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, DistinctOutput | undefined | null>> => {
+): Promise<Run<ParamValues, DistinctOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:mongodb_distinct",
     { collection, field, filter },

--- a/internal/builtins/rest.ts
+++ b/internal/builtins/rest.ts
@@ -1,5 +1,5 @@
 import { ClientOptions } from "../api/client";
-import { Run } from "../api/types";
+import { ParamValues, Run } from "../api/types";
 import { getRuntime } from "../runtime";
 
 export enum Method {
@@ -31,7 +31,7 @@ export const request = async (
   body: Record<string, unknown> | string | undefined | null = null,
   formData: Record<string, unknown> | undefined | null = null,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, RequestOutput | undefined | null>> => {
+): Promise<Run<ParamValues, RequestOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:rest_request",
     { method, path, headers, urlParams, bodyType, body, formData },

--- a/internal/builtins/slack.ts
+++ b/internal/builtins/slack.ts
@@ -1,12 +1,12 @@
 import { ClientOptions } from "../api/client";
-import { Run } from "../api/types";
+import { ParamValues, Run } from "../api/types";
 import { getRuntime } from "../runtime";
 
 export const message = async (
   channelName: string,
   message: string,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, undefined | null>> => {
+): Promise<Run<ParamValues, undefined | null>> => {
   return getRuntime().execute(
     "airplane:slack_message",
     { channelName, message },

--- a/internal/builtins/sql.ts
+++ b/internal/builtins/sql.ts
@@ -1,5 +1,5 @@
 import { ClientOptions } from "../api/client";
-import { Run } from "../api/types";
+import { ParamValues, Run } from "../api/types";
 import { getRuntime } from "../runtime";
 
 export enum TransactionMode {
@@ -17,7 +17,7 @@ export const query = async (
   queryArgs?: Record<string, unknown> | undefined | null,
   transactionMode: TransactionMode = TransactionMode.Auto,
   opts?: ClientOptions
-): Promise<Run<Record<string, unknown> | undefined | null, QueryOutput | undefined | null>> => {
+): Promise<Run<ParamValues, QueryOutput | undefined | null>> => {
   return getRuntime().execute(
     "airplane:sql_query",
     { query, queryArgs, transactionMode },

--- a/internal/execute.ts
+++ b/internal/execute.ts
@@ -1,11 +1,11 @@
 import { ClientOptions } from "./api/client";
-import { Run } from "./api/types";
+import { ParamValues, Run } from "./api/types";
 import { getRuntime } from "./runtime";
 
 export const execute = async <Output = unknown>(
   slug: string,
-  params?: Record<string, unknown> | undefined | null,
-  opts?: ClientOptions
+  params: ParamValues = {},
+  opts: ClientOptions = {}
 ): Promise<Run<typeof params, Output>> => {
   return getRuntime().execute(slug, params, {}, opts);
 };

--- a/internal/input/index.ts
+++ b/internal/input/index.ts
@@ -1,0 +1,32 @@
+import { ClientOptions } from "../api/client";
+import { ParamSchema } from "../api/types";
+import { getRuntime } from "../runtime";
+import { makeSlug } from "./slug";
+
+export type InputOptions<Type> = {
+  slug?: string;
+  description?: string;
+  required?: boolean;
+  default?: Type;
+  regex?: RegExp;
+  options?: Array<Type | { label: string; value: Type }>;
+  client?: ClientOptions;
+};
+
+export const text = async (name: string, opts: InputOptions<string> = {}): Promise<string> => {
+  const param: ParamSchema<"string"> = {
+    slug: opts.slug || makeSlug(name),
+    name,
+    type: "string",
+    constraints: {
+      optional: opts.required === false ? true : false,
+      options: opts.options,
+      regex: opts.regex?.source,
+    },
+    desc: opts.description,
+    default: opts.default,
+  };
+
+  const values = await getRuntime().prompt([param], opts.client);
+  return values[param.slug] as string;
+};

--- a/internal/input/slug.test.ts
+++ b/internal/input/slug.test.ts
@@ -1,0 +1,26 @@
+import { makeSlug } from "./slug";
+
+test("makeSlug", () => {
+  const cases = [
+    // no-op
+    ["test", "test"],
+    // removes casing
+    ["TEST", "test"],
+    // trims leading/trailing special characters
+    ["-a-", "a"],
+    // trims all whitespace
+    [" test that it trims space\t ", "test_that_it_trims_space"],
+    // removes special characters
+    ["foo-–—―&@%bar", "foo_and_at_percent_bar"],
+    // trims underscores
+    ["_test_foo_bar_", "test_foo_bar"],
+    // truncates long strings
+    ["a".repeat(100), "a".repeat(50)],
+    // trim duplicate __'s
+    ["test____test", "test_test"],
+  ];
+
+  for (const [i, o] of cases) {
+    expect(makeSlug(i)).toBe(o);
+  }
+});

--- a/internal/input/slug.ts
+++ b/internal/input/slug.ts
@@ -1,0 +1,37 @@
+const maxLength = 50;
+
+// makeSlug will convert a string into a valid slug, according to the
+// semantics of slugs used in the Airplane API. Emulates the
+// same gosimple/slug-based implementation.
+export const makeSlug = (s: string): string => {
+  s = s.trim().toLowerCase();
+
+  for (const [a, b] of Object.entries({
+    "‒": "_", // figure dash
+    "–": "_", // en dash
+    "—": "_", // em dash
+    "―": "_", // horizontal bar
+    "&": "and",
+    "@": "at",
+    "%": "percent",
+  })) {
+    // The extra "_"'s ensure these replacements aren't attached onto adjacent
+    // words. For example: 100% -> 100_percent
+    s = s.replace(new RegExp(a, "g"), "_" + b + "_");
+  }
+
+  // Replace non-authorized characters
+  s = s.replace(/[^a-z0-9_]/g, "_");
+
+  // Trim leading/trailing underscores
+  s = s.replace(/^_*/, "");
+  s = s.replace(/_*$/, "");
+
+  // Collapse any duplicate _'s
+  s = s.replace(/_+/g, "_");
+
+  // Trim to maxLength
+  s = s.substring(0, maxLength);
+
+  return s;
+};

--- a/internal/runtime/index.ts
+++ b/internal/runtime/index.ts
@@ -1,15 +1,17 @@
 import { ClientOptions } from "../api/client";
-import { Run } from "../api/types";
+import { ParamSchema, ParamValues, Run } from "../api/types";
 import { runtime as standardRuntime } from "./standard";
 import { runtime as workflowRuntime } from "./workflow";
 
 export type RuntimeInterface = {
   execute<Output = unknown>(
     slug: string,
-    params?: Record<string, unknown> | undefined | null,
+    params: ParamValues,
     resources?: Record<string, string> | undefined | null,
     opts?: ClientOptions
   ): Promise<Run<typeof params, Output>>;
+
+  prompt(params: ParamSchema[], opts?: ClientOptions): Promise<ParamValues>;
 };
 
 export enum RuntimeKind {

--- a/internal/runtime/workflow.ts
+++ b/internal/runtime/workflow.ts
@@ -2,7 +2,7 @@ import * as wf from "@temporalio/workflow";
 import { proxyActivities } from "@temporalio/workflow";
 
 import { Client, ClientOptions } from "../api/client";
-import { isStatusTerminal, Run, RunStatus } from "../api/types";
+import { isStatusTerminal, ParamSchema, ParamValues, Run, RunStatus } from "../api/types";
 import { RuntimeInterface } from "./index";
 
 // Recommended activity factory by Temporal: https://docs.temporal.io/typescript/activities/#important-design-patterns
@@ -37,7 +37,7 @@ const { executeTaskActivity, getRunOutputActivity } = proxyActivities<
 export const runtime: RuntimeInterface = {
   execute: async <Output = unknown>(
     slug: string,
-    params?: Record<string, unknown> | undefined | null,
+    params: ParamValues = {},
     resources?: Record<string, string> | undefined | null,
     opts: ClientOptions = {}
   ): Promise<Run<typeof params, Output>> => {
@@ -60,7 +60,7 @@ export const runtime: RuntimeInterface = {
     const taskSignal = wf.defineSignal<[runTerminationSignal]>(`${runID}-termination`);
 
     let taskID = "";
-    let paramValues: typeof params = undefined;
+    let paramValues: typeof params = {};
     let status: RunStatus = RunStatus.NotStarted;
     wf.setHandler(taskSignal, (payload: runTerminationSignal) => {
       taskID = payload.TaskID;
@@ -80,5 +80,9 @@ export const runtime: RuntimeInterface = {
       status,
       output,
     };
+  },
+
+  prompt: async (params: ParamSchema[], opts?: ClientOptions): Promise<ParamValues> => {
+    throw new Error(`Prompts are not yet supported by the workflow runtime`);
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airplane",
-  "version": "0.2.0-11",
+  "version": "0.2.0-12",
   "description": "Node.js SDK for writing Airplane.dev tasks",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Adds support for a single type of prompt: text strings. Follow-up PRs will add the remainder of the prompt kinds.

cc @kellymtrinh 

Resolves AIR-4114