### PR TITLE
Use resource aliases in builtin functions

### DIFF
--- a/internal/builtins/builtins.test.ts
+++ b/internal/builtins/builtins.test.ts
@@ -1,0 +1,53 @@
+import { convertResourceAliasToID } from "./builtins";
+
+describe("env", () => {
+  const env = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...env };
+  });
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  test("missing_resource_version", () => {
+    expect(() => {
+      convertResourceAliasToID("foo");
+    }).toThrow();
+  });
+
+  test("unsupported_resource_version", () => {
+    process.env.AIRPLANE_RESOURCES_VERSION = "3";
+
+    expect(() => {
+      convertResourceAliasToID("foo");
+    }).toThrow();
+  });
+
+  test("missing_alias", () => {
+    process.env.AIRPLANE_RESOURCES_VERSION = "2";
+    process.env.AIRPLANE_RESOURCES = "{}";
+
+    expect(() => {
+      convertResourceAliasToID("foo");
+    }).toThrow();
+  });
+
+  test("missing_id", () => {
+    process.env.AIRPLANE_RESOURCES_VERSION = "2";
+    process.env.AIRPLANE_RESOURCES = `{"foo": {}}`;
+
+    expect(() => {
+      convertResourceAliasToID("foo");
+    }).toThrow();
+  });
+
+  test("converts_alias", () => {
+    process.env.AIRPLANE_RESOURCES_VERSION = "2";
+    process.env.AIRPLANE_RESOURCES = `{"foo": {"id": "bar"}}`;
+
+    expect(convertResourceAliasToID("foo")).toBe("bar");
+  });
+});

--- a/internal/builtins/builtins.ts
+++ b/internal/builtins/builtins.ts
@@ -1,0 +1,18 @@
+export const convertResourceAliasToID = (alias: string) => {
+  const resources = JSON.parse(process.env.AIRPLANE_RESOURCES ?? "{}");
+  const resource_version = process.env.AIRPLANE_RESOURCES_VERSION ?? null;
+
+  if (!resource_version || resource_version !== "2") {
+    throw new Error("resources version unsupported");
+  }
+
+  if (!(alias in resources)) {
+    throw new Error(`resource alias ${alias} is unknown (have you attached the resource?)`);
+  }
+
+  if (!("id" in resources[alias])) {
+    throw new Error("unexpected resources env var format");
+  }
+
+  return resources[alias].id;
+};

--- a/internal/builtins/builtins.ts
+++ b/internal/builtins/builtins.ts
@@ -1,8 +1,8 @@
 export const convertResourceAliasToID = (alias: string) => {
   const resources = JSON.parse(process.env.AIRPLANE_RESOURCES ?? "{}");
-  const resource_version = process.env.AIRPLANE_RESOURCES_VERSION ?? null;
+  const resourceVersion = process.env.AIRPLANE_RESOURCES_VERSION ?? null;
 
-  if (!resource_version || resource_version !== "2") {
+  if (!resourceVersion || resourceVersion !== "2") {
     throw new Error("resources version unsupported");
   }
 

--- a/internal/builtins/email.ts
+++ b/internal/builtins/email.ts
@@ -11,7 +11,7 @@ export type Contact = {
 export type MessageOutput = Record<string, number>;
 
 export const message = async (
-  emailResourceAlias: string,
+  emailResource: string,
   sender: Contact,
   recipients: Contact[] | string[],
   subject = "",
@@ -21,7 +21,7 @@ export const message = async (
   return getRuntime().execute(
     "airplane:email_message",
     { sender, recipients, subject, message },
-    { email: convertResourceAliasToID(emailResourceAlias) },
+    { email: convertResourceAliasToID(emailResource) },
     opts
   );
 };

--- a/internal/builtins/email.ts
+++ b/internal/builtins/email.ts
@@ -1,6 +1,7 @@
 import { ClientOptions } from "../api/client";
 import { Run } from "../api/types";
 import { getRuntime } from "../runtime";
+import { convertResourceAliasToID } from "./builtins";
 
 export type Contact = {
   email: string;
@@ -10,7 +11,7 @@ export type Contact = {
 export type MessageOutput = Record<string, number>;
 
 export const message = async (
-  emailResourceID: string,
+  emailResourceAlias: string,
   sender: Contact,
   recipients: Contact[] | string[],
   subject = "",
@@ -20,7 +21,7 @@ export const message = async (
   return getRuntime().execute(
     "airplane:email_message",
     { sender, recipients, subject, message },
-    { email: emailResourceID },
+    { email: convertResourceAliasToID(emailResourceAlias) },
     opts
   );
 };

--- a/internal/builtins/mongodb.ts
+++ b/internal/builtins/mongodb.ts
@@ -1,11 +1,12 @@
 import { ClientOptions } from "../api/client";
 import { Run } from "../api/types";
 import { getRuntime } from "../runtime";
+import { convertResourceAliasToID } from "./builtins";
 
 export type DocumentOutput = Record<string, unknown>;
 
 export const find = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   filter: Record<string, unknown> | undefined | null = null,
   projection: Record<string, unknown> | undefined | null = null,
@@ -19,13 +20,13 @@ export const find = async (
   return getRuntime().execute(
     "airplane:mongodb_find",
     { collection, filter, projection, sort, skip, limit },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };
 
 export const findOne = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   filter: Record<string, unknown> | undefined | null = null,
   projection: Record<string, unknown> | undefined | null = null,
@@ -35,13 +36,13 @@ export const findOne = async (
   return getRuntime().execute(
     "airplane:mongodb_findOne",
     { collection, filter, projection, sort },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };
 
 export const findOneAndDelete = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   filter: Record<string, unknown> | undefined | null = null,
   projection: Record<string, unknown> | undefined | null = null,
@@ -51,13 +52,13 @@ export const findOneAndDelete = async (
   return getRuntime().execute(
     "airplane:mongodb_findOneAndDelete",
     { collection, filter, projection, sort },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };
 
 export const findOneAndUpdate = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   update: Record<string, unknown>,
   filter: Record<string, unknown> | undefined | null = null,
@@ -68,13 +69,13 @@ export const findOneAndUpdate = async (
   return getRuntime().execute(
     "airplane:mongodb_findOneAndUpdate",
     { collection, update, filter, projection, sort },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };
 
 export const findOneAndReplace = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   replacement: Record<string, unknown>,
   filter: Record<string, unknown> | undefined | null = null,
@@ -86,7 +87,7 @@ export const findOneAndReplace = async (
   return getRuntime().execute(
     "airplane:mongodb_findOneAndReplace",
     { collection, replacement, filter, projection, sort, upsert },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };
@@ -96,7 +97,7 @@ export type InsertOneOutput = {
 };
 
 export const insertOne = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   document: Record<string, unknown>,
   opts?: ClientOptions
@@ -104,7 +105,7 @@ export const insertOne = async (
   return getRuntime().execute(
     "airplane:mongodb_insertOne",
     { collection, document },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };
@@ -114,7 +115,7 @@ export type InsertManyOutput = {
 };
 
 export const insertMany = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   documents: Record<string, unknown>[],
   opts?: ClientOptions
@@ -124,7 +125,7 @@ export const insertMany = async (
   return getRuntime().execute(
     "airplane:mongodb_insertMany",
     { collection, documents },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };
@@ -137,7 +138,7 @@ export type UpdateOutput = {
 };
 
 export const updateOne = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   update: Record<string, unknown>,
   filter: Record<string, unknown> | undefined | null = null,
@@ -147,13 +148,13 @@ export const updateOne = async (
   return getRuntime().execute(
     "airplane:mongodb_updateOne",
     { collection, update, filter, upsert },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };
 
 export const updateMany = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   update: Record<string, unknown>,
   filter: Record<string, unknown> | undefined | null = null,
@@ -163,7 +164,7 @@ export const updateMany = async (
   return getRuntime().execute(
     "airplane:mongodb_updateMany",
     { collection, update, filter, upsert },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };
@@ -173,7 +174,7 @@ export type DeleteOutput = {
 };
 
 export const deleteOne = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   filter: Record<string, unknown>,
   opts?: ClientOptions
@@ -181,13 +182,13 @@ export const deleteOne = async (
   return getRuntime().execute(
     "airplane:mongodb_deleteOne",
     { collection, filter },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };
 
 export const deleteMany = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   filter: Record<string, unknown>,
   opts?: ClientOptions
@@ -195,13 +196,13 @@ export const deleteMany = async (
   return getRuntime().execute(
     "airplane:mongodb_deleteMany",
     { collection, filter },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };
 
 export const aggregate = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   pipeline: Record<string, unknown>[],
   opts?: ClientOptions
@@ -211,7 +212,7 @@ export const aggregate = async (
   return getRuntime().execute(
     "airplane:mongodb_aggregate",
     { collection, pipeline },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };
@@ -219,7 +220,7 @@ export const aggregate = async (
 export type CountOutput = number;
 
 export const countDocuments = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   filter: Record<string, unknown>,
   opts?: ClientOptions
@@ -227,7 +228,7 @@ export const countDocuments = async (
   return getRuntime().execute(
     "airplane:mongodb_countDocuments",
     { collection, filter },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };
@@ -235,7 +236,7 @@ export const countDocuments = async (
 export type DistinctOutput = unknown[];
 
 export const distinct = async (
-  mongodbResourceID: string,
+  mongodbResourceAlias: string,
   collection: string,
   field: string,
   filter: Record<string, unknown>,
@@ -244,7 +245,7 @@ export const distinct = async (
   return getRuntime().execute(
     "airplane:mongodb_distinct",
     { collection, field, filter },
-    { db: mongodbResourceID },
+    { db: convertResourceAliasToID(mongodbResourceAlias) },
     opts
   );
 };

--- a/internal/builtins/mongodb.ts
+++ b/internal/builtins/mongodb.ts
@@ -6,7 +6,7 @@ import { convertResourceAliasToID } from "./builtins";
 export type DocumentOutput = Record<string, unknown>;
 
 export const find = async (
-  mongodbResourceAlias: string,
+  mongodbResource: string,
   collection: string,
   filter: Record<string, unknown> | undefined | null = null,
   projection: Record<string, unknown> | undefined | null = null,
@@ -20,13 +20,13 @@ export const find = async (
   return getRuntime().execute(
     "airplane:mongodb_find",
     { collection, filter, projection, sort, skip, limit },
-    { db: convertResourceAliasToID(mongodbResourceAlias) },
+    { db: convertResourceAliasToID(mongodbResource) },
     opts
   );
 };
 
 export const findOne = async (
-  mongodbResourceAlias: string,
+  mongodbResource: string,
   collection: string,
   filter: Record<string, unknown> | undefined | null = null,
   projection: Record<string, unknown> | undefined | null = null,
@@ -36,13 +36,13 @@ export const findOne = async (
   return getRuntime().execute(
     "airplane:mongodb_findOne",
     { collection, filter, projection, sort },
-    { db: convertResourceAliasToID(mongodbResourceAlias) },
+    { db: convertResourceAliasToID(mongodbResource) },
     opts
   );
 };
 
 export const findOneAndDelete = async (
-  mongodbResourceAlias: string,
+  mongodbResource: string,
   collection: string,
   filter: Record<string, unknown> | undefined | null = null,
   projection: Record<string, unknown> | undefined | null = null,
@@ -52,13 +52,13 @@ export const findOneAndDelete = async (
   return getRuntime().execute(
     "airplane:mongodb_findOneAndDelete",
     { collection, filter, projection, sort },
-    { db: convertResourceAliasToID(mongodbResourceAlias) },
+    { db: convertResourceAliasToID(mongodbResource) },
     opts
   );
 };
 
 export const findOneAndUpdate = async (
-  mongodbResourceAlias: string,
+  mongodbResource: string,
   collection: string,
   update: Record<string, unknown>,
   filter: Record<string, unknown> | undefined | null = null,
@@ -69,13 +69,13 @@ export const findOneAndUpdate = async (
   return getRuntime().execute(
     "airplane:mongodb_findOneAndUpdate",
     { collection, update, filter, projection, sort },
-    { db: convertResourceAliasToID(mongodbResourceAlias) },
+    { db: convertResourceAliasToID(mongodbResource) },
     opts
   );
 };
 
 export const findOneAndReplace = async (
-  mongodbResourceAlias: string,
+  mongodbResource: string,
   collection: string,
   replacement: Record<string, unknown>,
   filter: Record<string, unknown> | undefined | null = null,
@@ -87,7 +87,7 @@ export const findOneAndReplace = async (
   return getRuntime().execute(
     "airplane:mongodb_findOneAndReplace",
     { collection, replacement, filter, projection, sort, upsert },
-    { db: convertResourceAliasToID(mongodbResourceAlias) },
+    { db: convertResourceAliasToID(mongodbResource) },
     opts
   );
 };
@@ -97,7 +97,7 @@ export type InsertOneOutput = {
 };
 
 export const insertOne = async (
-  mongodbResourceAlias: string,
+  mongodbResource: string,
   collection: string,
   document: Record<string, unknown>,
   opts?: ClientOptions
@@ -105,7 +105,7 @@ export const insertOne = async (
   return getRuntime().execute(
     "airplane:mongodb_insertOne",
     { collection, document },
-    { db: convertResourceAliasToID(mongodbResourceAlias) },
+    { db: convertResourceAliasToID(mongodbResource) },
     opts
   );
 };
@@ -115,7 +115,7 @@ export type InsertManyOutput = {
 };
 
 export const insertMany = async (
-  mongodbResourceAlias: string,
+  mongodbResource: string,
   collection: string,
   documents: Record<string, unknown>[],
   opts?: ClientOptions
@@ -125,7 +125,7 @@ export const insertMany = async (
   return getRuntime().execute(
     "airplane:mongodb_insertMany",
     { collection, documents },
-    { db: convertResourceAliasToID(mongodbResourceAlias) },
+    { db: convertResourceAliasToID(mongodbResource) },
     opts
   );
 };
@@ -138,7 +138,7 @@ export type UpdateOutput = {
 };
 
 export const updateOne = async (
-  mongodbResourceAlias: string,
+  mongodbResource: string,
   collection: string,
   update: Record<string, unknown>,
   filter: Record<string, unknown> | undefined | null = null,
@@ -148,13 +148,13 @@ export const updateOne = async (
   return getRuntime().execute(
     "airplane:mongodb_updateOne",
     { collection, update, filter, upsert },
-    { db: convertResourceAliasToID(mongodbResourceAlias) },
+    { db: convertResourceAliasToID(mongodbResource) },
     opts
   );
 };
 
 export const updateMany = async (
-  mongodbResourceAlias: string,
+  mongodbResource: string,
   collection: string,
   update: Record<string, unknown>,
   filter: Record<string, unknown> | undefined | null = null,
@@ -182,13 +182,13 @@ export const deleteOne = async (
   return getRuntime().execute(
     "airplane:mongodb_deleteOne",
     { collection, filter },
-    { db: convertResourceAliasToID(mongodbResourceAlias) },
+    { db: convertResourceAliasToID(mongodbResource) },
     opts
   );
 };
 
 export const deleteMany = async (
-  mongodbResourceAlias: string,
+  mongodbResource: string,
   collection: string,
   filter: Record<string, unknown>,
   opts?: ClientOptions
@@ -196,13 +196,13 @@ export const deleteMany = async (
   return getRuntime().execute(
     "airplane:mongodb_deleteMany",
     { collection, filter },
-    { db: convertResourceAliasToID(mongodbResourceAlias) },
+    { db: convertResourceAliasToID(mongodbResource) },
     opts
   );
 };
 
 export const aggregate = async (
-  mongodbResourceAlias: string,
+  mongodbResource: string,
   collection: string,
   pipeline: Record<string, unknown>[],
   opts?: ClientOptions
@@ -212,7 +212,7 @@ export const aggregate = async (
   return getRuntime().execute(
     "airplane:mongodb_aggregate",
     { collection, pipeline },
-    { db: convertResourceAliasToID(mongodbResourceAlias) },
+    { db: convertResourceAliasToID(mongodbResource) },
     opts
   );
 };
@@ -220,7 +220,7 @@ export const aggregate = async (
 export type CountOutput = number;
 
 export const countDocuments = async (
-  mongodbResourceAlias: string,
+  mongodbResource: string,
   collection: string,
   filter: Record<string, unknown>,
   opts?: ClientOptions
@@ -228,7 +228,7 @@ export const countDocuments = async (
   return getRuntime().execute(
     "airplane:mongodb_countDocuments",
     { collection, filter },
-    { db: convertResourceAliasToID(mongodbResourceAlias) },
+    { db: convertResourceAliasToID(mongodbResource) },
     opts
   );
 };
@@ -236,7 +236,7 @@ export const countDocuments = async (
 export type DistinctOutput = unknown[];
 
 export const distinct = async (
-  mongodbResourceAlias: string,
+  mongodbResource: string,
   collection: string,
   field: string,
   filter: Record<string, unknown>,
@@ -245,7 +245,7 @@ export const distinct = async (
   return getRuntime().execute(
     "airplane:mongodb_distinct",
     { collection, field, filter },
-    { db: convertResourceAliasToID(mongodbResourceAlias) },
+    { db: convertResourceAliasToID(mongodbResource) },
     opts
   );
 };

--- a/internal/builtins/rest.ts
+++ b/internal/builtins/rest.ts
@@ -23,7 +23,7 @@ export type RequestOutput = {
 };
 
 export const request = async (
-  restResourceAlias: string,
+  restResource: string,
   method: Method,
   path: string,
   headers: Record<string, unknown> = {},
@@ -36,7 +36,7 @@ export const request = async (
   return getRuntime().execute(
     "airplane:rest_request",
     { method, path, headers, urlParams, bodyType, body, formData },
-    { rest: convertResourceAliasToID(restResourceAlias) },
+    { rest: convertResourceAliasToID(restResource) },
     opts
   );
 };

--- a/internal/builtins/rest.ts
+++ b/internal/builtins/rest.ts
@@ -1,6 +1,7 @@
 import { ClientOptions } from "../api/client";
 import { Run } from "../api/types";
 import { getRuntime } from "../runtime";
+import { convertResourceAliasToID } from "./builtins";
 
 export enum Method {
   Get = "GET",
@@ -22,7 +23,7 @@ export type RequestOutput = {
 };
 
 export const request = async (
-  restResourceID: string,
+  restResourceAlias: string,
   method: Method,
   path: string,
   headers: Record<string, unknown> = {},
@@ -35,7 +36,7 @@ export const request = async (
   return getRuntime().execute(
     "airplane:rest_request",
     { method, path, headers, urlParams, bodyType, body, formData },
-    { rest: restResourceID },
+    { rest: convertResourceAliasToID(restResourceAlias) },
     opts
   );
 };

--- a/internal/builtins/sql.ts
+++ b/internal/builtins/sql.ts
@@ -1,6 +1,7 @@
 import { ClientOptions } from "../api/client";
 import { Run } from "../api/types";
 import { getRuntime } from "../runtime";
+import { convertResourceAliasToID } from "./builtins";
 
 export enum TransactionMode {
   Auto = "auto",
@@ -12,7 +13,7 @@ export enum TransactionMode {
 export type QueryOutput = Record<string, unknown[]>;
 
 export const query = async (
-  sqlResourceID: string,
+  sqlResourceAlias: string,
   query: string,
   queryArgs?: Record<string, unknown> | undefined | null,
   transactionMode: TransactionMode = TransactionMode.Auto,
@@ -21,7 +22,7 @@ export const query = async (
   return getRuntime().execute(
     "airplane:sql_query",
     { query, queryArgs, transactionMode },
-    { db: sqlResourceID },
+    { db: convertResourceAliasToID(sqlResourceAlias) },
     opts
   );
 };

--- a/internal/builtins/sql.ts
+++ b/internal/builtins/sql.ts
@@ -13,7 +13,7 @@ export enum TransactionMode {
 export type QueryOutput = Record<string, unknown[]>;
 
 export const query = async (
-  sqlResourceAlias: string,
+  sqlResource: string,
   query: string,
   queryArgs?: Record<string, unknown> | undefined | null,
   transactionMode: TransactionMode = TransactionMode.Auto,
@@ -22,7 +22,7 @@ export const query = async (
   return getRuntime().execute(
     "airplane:sql_query",
     { query, queryArgs, transactionMode },
-    { db: convertResourceAliasToID(sqlResourceAlias) },
+    { db: convertResourceAliasToID(sqlResource) },
     opts
   );
 };


### PR DESCRIPTION
Resolves AIR-4143

Switches over from resource ids to aliases now that resource attachments are out. Users will need to attach the resource and then refer to the resource via alias in all builtin functions.