### PR TITLE
Add support for setting output in workflow tasks

### DIFF
--- a/internal/output.ts
+++ b/internal/output.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid";
+import { getRuntime } from "./runtime";
 
 /**
  * This sets the Airplane output (`value`). If a path is provided, it sets the
@@ -31,7 +31,7 @@ export const setOutput = (value: unknown, ...path: (string | number)[]) => {
   const output = value === undefined ? null : JSON.stringify(value);
   const jsPath = toJSPath(path);
   const maybePath = jsPath ? `:${jsPath}` : "";
-  logChunks(`airplane_output_set${maybePath} ${output}`);
+  getRuntime().logChunks(`airplane_output_set${maybePath} ${output}`);
 };
 
 /**
@@ -63,20 +63,7 @@ export const appendOutput = (value: unknown, ...path: (string | number)[]) => {
   const output = value === undefined ? null : JSON.stringify(value);
   const jsPath = toJSPath(path);
   const maybePath = jsPath ? `:${jsPath}` : "";
-  logChunks(`airplane_output_append${maybePath} ${output}`);
-};
-
-const logChunks = (output: string) => {
-  const CHUNK_SIZE = 8192;
-  if (output.length <= CHUNK_SIZE) {
-    console.log(output);
-  } else {
-    const chunkKey = uuidv4();
-    for (let i = 0; i < output.length; i += CHUNK_SIZE) {
-      console.log(`airplane_chunk:${chunkKey} ${output.substr(i, CHUNK_SIZE)}`);
-    }
-    console.log(`airplane_chunk_end:${chunkKey}`);
-  }
+  getRuntime().logChunks(`airplane_output_append${maybePath} ${output}`);
 };
 
 const toJSPath = (path: (string | number)[]) => {

--- a/internal/runtime/index.ts
+++ b/internal/runtime/index.ts
@@ -12,6 +12,8 @@ export type RuntimeInterface = {
   ): Promise<Run<typeof params, Output>>;
 
   prompt(params: ParamSchema[], opts?: ClientOptions): Promise<ParamValues>;
+
+  logChunks(output: string): void;
 };
 
 export enum RuntimeKind {

--- a/internal/runtime/standard.ts
+++ b/internal/runtime/standard.ts
@@ -62,7 +62,7 @@ export const runtime: RuntimeInterface = {
     } else {
       const chunkKey = uuidv4();
       for (let i = 0; i < output.length; i += CHUNK_SIZE) {
-        console.log(`airplane_chunk:${chunkKey} ${output.substring(i, CHUNK_SIZE)}`);
+        console.log(`airplane_chunk:${chunkKey} ${output.substring(i, i + CHUNK_SIZE)}`);
       }
       console.log(`airplane_chunk_end:${chunkKey}`);
     }

--- a/internal/runtime/standard.ts
+++ b/internal/runtime/standard.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
+
 import { Client, ClientOptions } from "../api/client";
 import { Poller } from "../api/poller";
 import { isStatusTerminal, ParamSchema, ParamValues, Run } from "../api/types";
@@ -51,5 +53,18 @@ export const runtime: RuntimeInterface = {
 
       return prompt.values;
     });
+  },
+
+  logChunks: (output: string): void => {
+    const CHUNK_SIZE = 8192;
+    if (output.length <= CHUNK_SIZE) {
+      console.log(output);
+    } else {
+      const chunkKey = uuidv4();
+      for (let i = 0; i < output.length; i += CHUNK_SIZE) {
+        console.log(`airplane_chunk:${chunkKey} ${output.substring(i, CHUNK_SIZE)}`);
+      }
+      console.log(`airplane_chunk_end:${chunkKey}`);
+    }
   },
 };

--- a/internal/runtime/workflow.ts
+++ b/internal/runtime/workflow.ts
@@ -117,7 +117,7 @@ export const runtime: RuntimeInterface = {
     } else {
       const chunkKey = wf.uuid4();
       for (let i = 0; i < output.length; i += CHUNK_SIZE) {
-        logger.info(`airplane_chunk:${chunkKey} ${output.substr(i, CHUNK_SIZE)}`);
+        logger.info(`airplane_chunk:${chunkKey} ${output.substring(i, i + CHUNK_SIZE)}`);
       }
       logger.info(`airplane_chunk_end:${chunkKey}`);
     }

--- a/internal/runtime/workflow.ts
+++ b/internal/runtime/workflow.ts
@@ -1,5 +1,6 @@
 import * as wf from "@temporalio/workflow";
-import { proxyActivities } from "@temporalio/workflow";
+import { proxyActivities, proxySinks } from "@temporalio/workflow";
+const { logger } = proxySinks();
 
 import { Client, ClientOptions } from "../api/client";
 import { isStatusTerminal, ParamSchema, ParamValues, Run, RunStatus } from "../api/types";
@@ -107,6 +108,19 @@ export const runtime: RuntimeInterface = {
     await wf.condition(() => done);
 
     return values;
+  },
+
+  logChunks: (output: string): void => {
+    const CHUNK_SIZE = 8192;
+    if (output.length <= CHUNK_SIZE) {
+      logger.info(output);
+    } else {
+      const chunkKey = wf.uuid4();
+      for (let i = 0; i < output.length; i += CHUNK_SIZE) {
+        logger.info(`airplane_chunk:${chunkKey} ${output.substr(i, CHUNK_SIZE)}`);
+      }
+      logger.info(`airplane_chunk_end:${chunkKey}`);
+    }
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airplane",
-  "version": "0.2.0-15",
+  "version": "0.2.0-16",
   "description": "Node.js SDK for writing Airplane.dev tasks",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This PR adds workflow task support for the `setOutput` and `appendOutput` methods of our SDK - we move `logChunks` to the runtime interface because its implementation varies depending on whether the task is a standard or workflow task. 

For standard tasks, we log to stdout and utilize the uuid package to generate chunk keys. For workflow tasks, however, we must log to a sink , and also use Temporal's `uuid` method, which generates UUIDs with a seed that is derived from the workflow id, and so guarantees workflow determinism.

Also changes any references of `substr` -> `substring` since the former has been deprecated.