### PR TITLE
Throw error when child runs fail

### DIFF
--- a/internal/errors.test.ts
+++ b/internal/errors.test.ts
@@ -1,7 +1,7 @@
 import { Run, RunStatus } from "./api/types";
-import { RunError } from "./errors";
+import { RunTerminationError } from "./errors";
 
-test("RunError", () => {
+test("RunTerminationError", () => {
   const run: Run = {
     id: "run123",
     output: "hello world",
@@ -13,14 +13,14 @@ test("RunError", () => {
   };
 
   try {
-    throw new RunError(run);
+    throw new RunTerminationError(run);
   } catch (err: unknown) {
-    if (err instanceof RunError) {
-      expect(err.name).toBe("RunError");
+    if (err instanceof RunTerminationError) {
+      expect(err.name).toBe("RunTerminationError");
       expect(err.message).toBe("Run failed");
       expect(err.run).toBe(run);
     } else {
-      fail("err is not a RunError");
+      fail("err is not a RunTerminationError");
     }
   }
 });

--- a/internal/errors.test.ts
+++ b/internal/errors.test.ts
@@ -1,0 +1,26 @@
+import { Run, RunStatus } from "./api/types";
+import { RunError } from "./errors";
+
+test("RunError", () => {
+  const run: Run = {
+    id: "run123",
+    output: "hello world",
+    paramValues: {
+      name: "world",
+    },
+    status: RunStatus.Failed,
+    taskID: "tsk123",
+  };
+
+  try {
+    throw new RunError(run);
+  } catch (err: unknown) {
+    if (err instanceof RunError) {
+      expect(err.name).toBe("RunError");
+      expect(err.message).toBe("Run failed");
+      expect(err.run).toBe(run);
+    } else {
+      fail("err is not a RunError");
+    }
+  }
+});

--- a/internal/errors.ts
+++ b/internal/errors.ts
@@ -1,0 +1,11 @@
+import { ParamValues, Run } from "./api/types";
+
+export class RunError<
+  TParamValues extends ParamValues = ParamValues,
+  TOutput = unknown
+> extends Error {
+  constructor(public readonly run: Run<TParamValues, TOutput>) {
+    super(`Run ${run.status.toLowerCase()}`);
+    this.name = "RunError";
+  }
+}

--- a/internal/errors.ts
+++ b/internal/errors.ts
@@ -1,11 +1,11 @@
 import { ParamValues, Run } from "./api/types";
 
-export class RunError<
+export class RunTerminationError<
   TParamValues extends ParamValues = ParamValues,
   TOutput = unknown
 > extends Error {
   constructor(public readonly run: Run<TParamValues, TOutput>) {
     super(`Run ${run.status.toLowerCase()}`);
-    this.name = "RunError";
+    this.name = "RunTerminationError";
   }
 }

--- a/internal/execute.ts
+++ b/internal/execute.ts
@@ -1,5 +1,6 @@
 import { ClientOptions } from "./api/client";
-import { ParamValues, Run } from "./api/types";
+import { ParamValues, Run, RunStatus } from "./api/types";
+import { RunError } from "./errors";
 import { getRuntime } from "./runtime";
 
 export const execute = async <Output = unknown>(
@@ -7,5 +8,11 @@ export const execute = async <Output = unknown>(
   params: ParamValues = {},
   opts: ClientOptions = {}
 ): Promise<Run<typeof params, Output>> => {
-  return getRuntime().execute(slug, params, {}, opts);
+  const run = await getRuntime().execute<Output>(slug, params, {}, opts);
+
+  if (run.status === RunStatus.Failed || run.status === RunStatus.Cancelled) {
+    throw new RunError(run);
+  }
+
+  return run;
 };

--- a/internal/execute.ts
+++ b/internal/execute.ts
@@ -1,6 +1,6 @@
 import { ClientOptions } from "./api/client";
 import { ParamValues, Run, RunStatus } from "./api/types";
-import { RunError } from "./errors";
+import { RunTerminationError } from "./errors";
 import { getRuntime } from "./runtime";
 
 export const execute = async <Output = unknown>(
@@ -11,7 +11,7 @@ export const execute = async <Output = unknown>(
   const run = await getRuntime().execute<Output>(slug, params, {}, opts);
 
   if (run.status === RunStatus.Failed || run.status === RunStatus.Cancelled) {
-    throw new RunError(run);
+    throw new RunTerminationError(run);
   }
 
   return run;


### PR DESCRIPTION
When a run fails (or is cancelled), throw an error that a user can optionally catch. IOW, by default a failed child run will fail the parent run.

Resolves AIR-4093