### PR TITLE
Use camel case field names in signal

### DIFF
--- a/internal/runtime/workflow.ts
+++ b/internal/runtime/workflow.ts
@@ -51,12 +51,12 @@ export const runtime: RuntimeInterface = {
 
     // Register termination signal for the workflow. We ensure signal name uniqueness by including the run ID of the task
     // being executed in the signal name, as a workflow task may execute any number of other tasks.
-    const taskSignal = wf.defineSignal<
+    const signal = wf.defineSignal<
       [
         {
-          TaskID: string;
-          ParamValues: typeof params;
-          Status: RunStatus;
+          taskID: string;
+          paramValues: typeof params;
+          status: RunStatus;
         }
       ]
     >(`${runID}-termination`);
@@ -64,10 +64,10 @@ export const runtime: RuntimeInterface = {
     let taskID = "";
     let paramValues: typeof params = {};
     let status: RunStatus = RunStatus.NotStarted;
-    wf.setHandler(taskSignal, (payload) => {
-      taskID = payload.TaskID;
-      paramValues = payload.ParamValues;
-      status = payload.Status;
+    wf.setHandler(signal, (payload) => {
+      taskID = payload.taskID;
+      paramValues = payload.paramValues;
+      status = payload.status;
     });
 
     // Defer workflow execution until the task has been completed.
@@ -92,7 +92,7 @@ export const runtime: RuntimeInterface = {
     const signal = wf.defineSignal<
       [
         {
-          Values: ParamValues;
+          values: ParamValues;
         }
       ]
     >(`${promptID}-submitted`);
@@ -100,7 +100,7 @@ export const runtime: RuntimeInterface = {
     let done = false;
     let values: ParamValues = {};
     wf.setHandler(signal, (payload) => {
-      values = payload.Values;
+      values = payload.values;
       done = true;
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airplane",
-  "version": "0.2.0-17",
+  "version": "0.2.0-18",
   "description": "Node.js SDK for writing Airplane.dev tasks",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
We've modified our API to send signals with camel case field names, in accordance with standard JSON field names - this PR changes the signals' types to use these updated field names.