### PR TITLE
Add dev runtime

### DIFF
--- a/internal/runtime/dev.ts
+++ b/internal/runtime/dev.ts
@@ -1,0 +1,60 @@
+import { v4 as uuidv4 } from "uuid";
+
+import { Client, ClientOptions } from "../api/client";
+import { Poller } from "../api/poller";
+import { ParamSchema, ParamValues, Run } from "../api/types";
+import { RuntimeInterface } from "./index";
+
+export const runtime: RuntimeInterface = {
+  execute: async <Output = unknown>(
+    slug: string,
+    params: ParamValues = {},
+    resources?: Record<string, string> | undefined | null,
+    opts: ClientOptions = {}
+  ): Promise<Run<typeof params, Output>> => {
+    const client = new Client(opts);
+
+    const runID = await client.executeTask(slug, params, resources);
+    const run = await client.getRun<typeof params>(runID);
+    const output = await client.getRunOutput<Output>(runID);
+
+    return {
+      id: run.id,
+      taskID: run.taskID,
+      paramValues: run.paramValues,
+      status: run.status,
+      output,
+    };
+  },
+
+  prompt: async (params: ParamSchema[], opts?: ClientOptions): Promise<ParamValues> => {
+    const client = new Client(opts);
+
+    const id = await client.createPrompt(params);
+
+    // Poll until the prompt is submitted:
+    const poller = new Poller({ delayMs: 500 });
+    return poller.run(async () => {
+      const prompt = await client.getPrompt(id);
+
+      if (prompt.submittedAt == null) {
+        return null;
+      }
+
+      return prompt.values;
+    });
+  },
+
+  logChunks: (output: string): void => {
+    const CHUNK_SIZE = 8192;
+    if (output.length <= CHUNK_SIZE) {
+      console.log(output);
+    } else {
+      const chunkKey = uuidv4();
+      for (let i = 0; i < output.length; i += CHUNK_SIZE) {
+        console.log(`airplane_chunk:${chunkKey} ${output.substring(i, i + CHUNK_SIZE)}`);
+      }
+      console.log(`airplane_chunk_end:${chunkKey}`);
+    }
+  },
+};

--- a/internal/runtime/dev.ts
+++ b/internal/runtime/dev.ts
@@ -1,9 +1,7 @@
-import { v4 as uuidv4 } from "uuid";
-
 import { Client, ClientOptions } from "../api/client";
-import { Poller } from "../api/poller";
 import { ParamSchema, ParamValues, Run } from "../api/types";
 import { RuntimeInterface } from "./index";
+import { runtime as standardRuntime } from "./standard";
 
 export const runtime: RuntimeInterface = {
   execute: async <Output = unknown>(
@@ -28,33 +26,10 @@ export const runtime: RuntimeInterface = {
   },
 
   prompt: async (params: ParamSchema[], opts?: ClientOptions): Promise<ParamValues> => {
-    const client = new Client(opts);
-
-    const id = await client.createPrompt(params);
-
-    // Poll until the prompt is submitted:
-    const poller = new Poller({ delayMs: 500 });
-    return poller.run(async () => {
-      const prompt = await client.getPrompt(id);
-
-      if (prompt.submittedAt == null) {
-        return null;
-      }
-
-      return prompt.values;
-    });
+    return standardRuntime.prompt(params, opts);
   },
 
   logChunks: (output: string): void => {
-    const CHUNK_SIZE = 8192;
-    if (output.length <= CHUNK_SIZE) {
-      console.log(output);
-    } else {
-      const chunkKey = uuidv4();
-      for (let i = 0; i < output.length; i += CHUNK_SIZE) {
-        console.log(`airplane_chunk:${chunkKey} ${output.substring(i, i + CHUNK_SIZE)}`);
-      }
-      console.log(`airplane_chunk_end:${chunkKey}`);
-    }
+    return standardRuntime.logChunks(output);
   },
 };

--- a/internal/runtime/index.ts
+++ b/internal/runtime/index.ts
@@ -1,5 +1,6 @@
 import { ClientOptions } from "../api/client";
 import { ParamSchema, ParamValues, Run } from "../api/types";
+import { runtime as devRuntime } from "./dev";
 import { runtime as standardRuntime } from "./standard";
 import { runtime as workflowRuntime } from "./workflow";
 
@@ -19,9 +20,17 @@ export type RuntimeInterface = {
 export enum RuntimeKind {
   Standard = "standard",
   Workflow = "workflow",
+  Dev = "dev",
 }
 
 export const getRuntime = () => {
   const kind = globalThis.process?.env.AIRPLANE_RUNTIME;
-  return kind === RuntimeKind.Workflow ? workflowRuntime : standardRuntime;
+  switch (kind) {
+    case RuntimeKind.Workflow:
+      return workflowRuntime;
+    case RuntimeKind.Dev:
+      return devRuntime;
+    default:
+      return standardRuntime;
+  }
 };


### PR DESCRIPTION
Adds a new runtime type, `dev`, to the Node SDK - previously, `airplane dev` was using the standard runtime methods (successfully); however, this PR formalizes the notion of a new dev runtime with some minor differences from the standard runtime. For example, we don't need to poll for the run to finish - in our local dev api server implementation of `/tasks/execute`, we set the status of the run so there's no need to wait for `/runs/get` to return a result. For now, the `prompt` and `logChunks` methods just reference the standard runtime implementation.