### PR TITLE
Don't retry temporal activities

### DIFF
--- a/internal/runtime/workflow.ts
+++ b/internal/runtime/workflow.ts
@@ -37,6 +37,9 @@ const { executeTaskActivity, getRunOutputActivity, createPromptActivity } = prox
   ReturnType<typeof createActivities>
 >({
   startToCloseTimeout: "120s",
+  retry: {
+    maximumAttempts: 1,
+  },
 });
 
 export const runtime: RuntimeInterface = {


### PR DESCRIPTION
By default, temporal activities are retried indefinitely: https://docs.temporal.io/retry-policies/#default-values-for-retry-policy - this is not behavior we'd like since that means multiple child runs could get created in the case of transient temporal failures. In that case, we'd like to fail the workflow entirely - this PR sets the maximum number of attempts in any Node SDK activity to be at most 1 so that retries never occur.