### PR TITLE
Fix airplane runtime detection

### DIFF
--- a/internal/config.ts
+++ b/internal/config.ts
@@ -1,6 +1,5 @@
 import { execute } from "./execute";
 import { Param, JSParamValues, ParamTypes } from "./parameters";
-import { RuntimeKind } from "./runtime";
 
 export type ParamType<TSchema extends ParamTypes | Param> = TSchema extends Param
   ? TSchema["type"]
@@ -34,8 +33,7 @@ export const task = <TParams extends Params, TOutput>(
   config: TaskConfig<TParams>,
   f: UserFunc<TParams, TOutput>
 ): AirplaneFunc<TParams, TOutput> => {
-  const runtime = process.env.AIRPLANE_RUNTIME ?? "";
-  const inAirplaneRuntime = runtime === RuntimeKind.Standard || runtime === RuntimeKind.Workflow;
+  const inAirplaneRuntime = !!(process.env.AIRPLANE_RUN_ID ?? "");
 
   const wrappedF = async (params: ParamValues<TParams>): Promise<Awaited<TOutput>> => {
     if (inAirplaneRuntime) {

--- a/internal/config.ts
+++ b/internal/config.ts
@@ -1,5 +1,6 @@
 import { execute } from "./execute";
 import { Param, JSParamValues, ParamTypes } from "./parameters";
+import { RuntimeKind } from "./runtime";
 
 export type ParamType<TSchema extends ParamTypes | Param> = TSchema extends Param
   ? TSchema["type"]
@@ -33,7 +34,8 @@ export const task = <TParams extends Params, TOutput>(
   config: TaskConfig<TParams>,
   f: UserFunc<TParams, TOutput>
 ): AirplaneFunc<TParams, TOutput> => {
-  const inAirplaneRuntime = !!(process.env.AIRPLANE_RUN_ID ?? "");
+  const inAirplaneRuntime =
+    process.env.AIRPLANE_RUNTIME !== undefined && process.env.AIRPLANE_RUNTIME !== RuntimeKind.Dev;
 
   const wrappedF = async (params: ParamValues<TParams>): Promise<Awaited<TOutput>> => {
     if (inAirplaneRuntime) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airplane",
-  "version": "0.2.0-20",
+  "version": "0.2.0-21",
   "description": "Node.js SDK for writing Airplane.dev tasks",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
The standard runtime can set the value of the runtime variable to a blank string. Check instead that the runtime env var is defined and not "dev".