### PR TITLE
Remove reliance on process

### DIFF
--- a/internal/config.ts
+++ b/internal/config.ts
@@ -36,7 +36,7 @@ export const task = <TParams extends Params, TOutput>(
 ): AirplaneFunc<TParams, TOutput> => {
   const env = globalThis.process?.env;
   const inAirplaneRuntime =
-    env && env.AIRPLANE_RUNTIME !== undefined && env.AIRPLANE_RUNTIME !== RuntimeKind.Dev;
+    !env || (env.AIRPLANE_RUNTIME !== undefined && env.AIRPLANE_RUNTIME !== RuntimeKind.Dev);
 
   const wrappedF = async (params: ParamValues<TParams>): Promise<Awaited<TOutput>> => {
     if (inAirplaneRuntime) {

--- a/internal/config.ts
+++ b/internal/config.ts
@@ -34,8 +34,9 @@ export const task = <TParams extends Params, TOutput>(
   config: TaskConfig<TParams>,
   f: UserFunc<TParams, TOutput>
 ): AirplaneFunc<TParams, TOutput> => {
+  const env = globalThis.process?.env;
   const inAirplaneRuntime =
-    process.env.AIRPLANE_RUNTIME !== undefined && process.env.AIRPLANE_RUNTIME !== RuntimeKind.Dev;
+    env && env.AIRPLANE_RUNTIME !== undefined && env.AIRPLANE_RUNTIME !== RuntimeKind.Dev;
 
   const wrappedF = async (params: ParamValues<TParams>): Promise<Awaited<TOutput>> => {
     if (inAirplaneRuntime) {


### PR DESCRIPTION
Remove reliance on process so this can be used outside of node.

If called from outside of node, always execute in the airplane runtime. We might revisit this in the future, but I think this is the correct path at least for now.