### PR TITLE
Update generic type of airplane func

### DIFF
--- a/internal/config.test.ts
+++ b/internal/config.test.ts
@@ -1,0 +1,118 @@
+import { task } from "./config";
+
+describe("config", () => {
+  describe("local execution", () => {
+    it("executes a task with a simple param", async () => {
+      const myTask = task(
+        {
+          slug: "hello",
+          name: "Hello task",
+          parameters: {
+            name: {
+              type: "shorttext",
+              description: "Your name!",
+            },
+          },
+        },
+        (params) => {
+          return `Hello ${params.name}!`;
+        }
+      );
+
+      const res = await myTask({ name: "Lee" });
+      expect(res).toBe("Hello Lee!");
+    });
+
+    it("executes a task with a simple shorthand param", async () => {
+      const myTask = task(
+        {
+          slug: "hello",
+          name: "Hello task",
+          parameters: {
+            name: "shorttext",
+          },
+        },
+        (params) => {
+          return `Hello ${params.name}!`;
+        }
+      );
+
+      const res = await myTask({ name: "Lee" });
+      expect(res).toBe("Hello Lee!");
+    });
+
+    it("executes a task with multiple params", async () => {
+      const myTask = task(
+        {
+          slug: "hello",
+          name: "Hello task",
+          parameters: {
+            name: {
+              type: "shorttext",
+              description: "Your name!",
+            },
+            greeting: {
+              type: "longtext",
+              description: "Greeting",
+            },
+            excited: {
+              type: "boolean",
+            },
+          },
+        },
+        (params) => {
+          return `${params.greeting} ${params.name}${params.excited ? "!" : "."}`;
+        }
+      );
+
+      const res = await myTask({ name: "Lee", greeting: "Hi", excited: true });
+      expect(res).toBe("Hi Lee!");
+    });
+
+    it("executes a task with an optional param", async () => {
+      const myTask = task(
+        {
+          slug: "hello",
+          name: "Hello task",
+          parameters: {
+            name: {
+              type: "shorttext",
+              description: "Your name!",
+              default: "Lee",
+              required: false,
+            },
+          },
+        },
+        (params) => {
+          return `Hello ${params.name}!`;
+        }
+      );
+
+      // TODO this should work
+      // const res = await myTask();
+      // expect(res).toBe("Hello Lee!");
+
+      const res = await myTask({ name: "Colin" });
+      expect(res).toBe("Hello Colin!");
+    });
+
+    it("executes a task with no params", async () => {
+      const myTask = task(
+        {
+          slug: "hello",
+          name: "Hello task",
+        },
+        () => {
+          return `Hello!`;
+        }
+      );
+
+      // TODO this should work
+      // const res = await myTask();
+      // expect(res).toBe("Hello!");
+
+      const res = await myTask({});
+      expect(res).toBe("Hello!");
+    });
+  });
+});

--- a/internal/config.ts
+++ b/internal/config.ts
@@ -1,3 +1,4 @@
+import { ParamValues as APIParamValues } from "./api/types";
 import { execute } from "./execute";
 import { Param, JSParamValues, ParamTypes } from "./parameters";
 import { RuntimeKind } from "./runtime";
@@ -26,16 +27,18 @@ export type TaskConfig<TParams extends Params> = {
 
 export type UserFunc<TParams extends Params, TOutput> = (params: ParamValues<TParams>) => TOutput;
 
-export type AirplaneFunc<TParams extends Params, TOutput> = (
-  params: ParamValues<TParams>
+export type AirplaneFunc<TParams extends APIParamValues, TOutput> = (
+  params: TParams
 ) => Promise<Awaited<TOutput>>;
 
 export const task = <TParams extends Params, TOutput>(
   config: TaskConfig<TParams>,
   f: UserFunc<TParams, TOutput>
-): AirplaneFunc<TParams, TOutput> => {
+): AirplaneFunc<ParamValues<TParams>, TOutput> => {
   const inAirplaneRuntime =
-    process.env.AIRPLANE_RUNTIME !== undefined && process.env.AIRPLANE_RUNTIME !== RuntimeKind.Dev;
+    typeof process === "undefined" ||
+    (process.env.AIRPLANE_RUNTIME !== undefined &&
+      process.env.AIRPLANE_RUNTIME !== RuntimeKind.Dev);
 
   const wrappedF = async (params: ParamValues<TParams>): Promise<Awaited<TOutput>> => {
     if (inAirplaneRuntime) {


### PR DESCRIPTION
Let's discuss this, but I think it's the correct move and would make integrating this into views much simpler.

The returned AirplaneFunc should not rely on the input params of `task`, but instead should be a function that can call the airplane backend regardless of the task configuration.

I also added a few tests.

Also added a proposal for always executing in an airplane runtime if executed from a non-nodejs environment